### PR TITLE
Prehlásenie -> Vyhlásenie

### DIFF
--- a/locale/slovak.dtx
+++ b/locale/slovak.dtx
@@ -33,7 +33,7 @@
     Namiesto tejto stránky vložte kópiu oficiálneho podpísaného
     zadania práce.
   \fi}
-\gdef\thesis@slovak@declaration{Text prehlásenie ...}
+\gdef\thesis@slovak@declaration{Text vyhlásenie ...}
 
 % Časové údaje
 \gdef\thesis@slovak@spring{jar}
@@ -48,7 +48,7 @@
 \gdef\thesis@slovak@abstractTitle{Zhrnutie}
 \gdef\thesis@slovak@keywordsTitle{Kľúčové slová}
 \gdef\thesis@slovak@thanksTitle{Poďakovanie}
-\gdef\thesis@slovak@declarationTitle{Prehlásenie}
+\gdef\thesis@slovak@declarationTitle{Vyhlásenie}
 \gdef\thesis@slovak@idTitle{ID}
 \gdef\thesis@slovak@typeName@sempaper{Seminárna práca}
 \gdef\thesis@slovak@typeName@bachelors{Bakalárska práca}
@@ -109,7 +109,7 @@
 % Zástupné texty
 \gdef\thesis@slovak@universityName{Masarykova univerzita}
 \gdef\thesis@slovak@declaration{%
-  Prehlasujem, že som predloženú \thesis@lower{%
+  Vyhlasujem, že som predloženú \thesis@lower{%
   slovak@typeName@akuzativ} vypracoval%
   \thesis@slovak@gender@koncovka\ samostatne len s~použitím
   uvedenej literatúry a prameňov.}
@@ -177,11 +177,11 @@
 \gdef\thesis@slovak@assignment{%
   \ifthesis@digital@
     Na tomto mieste sa v~tlačenej práci nachádza oficiálne
-    podpísané zadanie práce alebo prehlásenie autora školského
+    podpísané zadanie práce alebo vyhlásenie autora školského
     diela alebo obidve.
   \else
     Namiesto tejto stránky vložte kópiu oficiálneho podpísaného
-    zadania práce alebo prehlásenie autora školského diela alebo
+    zadania práce alebo vyhlásenie autora školského diela alebo
     obidve~v závislosti na požiadavkách príslušnej katedry.
   \fi}
 %    \end{macrocode}\iffalse
@@ -241,13 +241,13 @@
 \gdef\thesis@slovak@assignment{%
   \ifthesis@digital@
     Na tomto mieste sa v~tlačenej práci nachádza oficiálne
-    podpísané zadanie práce a prehlásenie autora školského diela.
+    podpísané zadanie práce a vyhlásenie autora školského diela.
   \else
     Namiesto tejto stránky vložte kópiu oficiálneho podpísaného
-    zadania práce a prehlásenie autora školského diela.
+    zadania práce a vyhlásenie autora školského diela.
   \fi}
 \gdef\thesis@slovak@declaration{%
-  Prehlasujem, že táto \thesis@lower{slovak@typeName} je mojím
+  vyhlasujem, že táto \thesis@lower{slovak@typeName} je mojím
   pôvodným autorským dielom, ktoré som vypracoval%
   \thesis@slovak@gender@koncovka\ samostatne. Všetky zdroje,
   pramene a literatúru, ktoré som pri vypracovaní
@@ -289,14 +289,14 @@
   \fi}
 \gdef\thesis@czech@declaration{%
   \ifx\thesis@department\thesis@departments@kisk
-    Prehlasujem, že som predkladanú prácu spracoval%
+    Vyhlasujem, že som predkladanú prácu spracoval%
     \thesis@slovak@gender@koncovka\ samostatne~a použil%
     \thesis@slovak@gender@koncovka\ len uvedené pramene~a
     literatúru. Súčasne dávam súhlas k tomu, aby elektronická
     verzia tejto práce bola sprístupnená cez informačný
     systém Masarykovej univerzity.%
   \else
-    Prehlasujem, že som predloženú \thesis@lower{%
+    Vyhlasujem, že som predloženú \thesis@lower{%
     slovak@typeName@akuzativ} vypracoval%
     \thesis@slovak@gender@koncovka\ samostatne na základe vlastných
     zistení a len s~použitím uvedenej literatúry a prameňov.%


### PR DESCRIPTION
V slovenčine slovo `prehlásenie` nemá rovnaký význam ako české `prohlášení`, adevátny preklad je `vyhlásenie`.

Viz.
http://slovniky.juls.savba.sk/?w=prehl%C3%A1si%C5%A5&s=exact&c=qb63&d=kssj4&d=psp&d=sssj&d=sssj2&d=scs&d=sss&d=peciar&ie=utf-8&oe=utf-8#
http://jazykovaporadna.sme.sk/q/8662/