### PR TITLE
Update latexmkrc -- missing semicolon

### DIFF
--- a/example/mu/latexmkrc
+++ b/example/mu/latexmkrc
@@ -1,2 +1,2 @@
 $makeindex = "texindy %O -I latex -C utf8 -L english -o %D %S";
-$pdflatex = "pdflatex --shell-escape %O %S"
+$pdflatex = "pdflatex --shell-escape %O %S";


### PR DESCRIPTION
There is missing a semicolon after the statement in the configuration file of the `latexmk` tool. It is obviously `perl` syntax.

Ref: https://mg.readthedocs.io/latexmk.html#local-configuration-files
