### PR TITLE
[econ] Fix Slovak localization uvedla..uviedla / uvediol..uviedol

### DIFF
--- a/locale/slovak.dtx
+++ b/locale/slovak.dtx
@@ -321,7 +321,7 @@
   \thesis@lower{slovak@typeName@akuzativ} \thesis@title{} spracoval%
   \thesis@slovak@gender@koncovka\ samostatne pod vedením
   \thesis@extra@advisorSkGenitiv\ 
-  a~uved\ifthesis@woman la\else iol\fi\ v~nej všetky
+  a~uvied\ifthesis@woman la\else ol\fi\ v~nej všetky
   odborné zdroje v~súlade s~právnymi predpismi, vnútornými
   predpismi Masarykovej univerzity a~vnútornými aktmi riadenia
   Masarykovej univerzity a~Ekonomicko-správnej fakulty MU.}


### PR DESCRIPTION
Just a reported typo in the declaration part in Slovak for the Faculty of Economics and Administration.